### PR TITLE
fix: Add missing Analytics Base Url

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
 # Changes here will be overwritten by Copier
-_commit: 0af2c45
+_commit: d4927ca
 _src_path: git@github.com:la-famiglia-jst2324/parma-mining-template.git
 module_name: producthunt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ defaults:
   run:
     shell: bash -el {0}
 
+env:
+  TF_VAR_ANALYTICS_BASE_URL: ${{ github.event_name == 'release' && vars.PROD_ANALYTICS_BASE_URL || vars.STAGING_ANALYTICS_BASE_URL}}
+
 jobs:
   deploy:
     name: Deploy - ${{ matrix.DEPLOYMENT_ENV }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ WORKDIR /app
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER parma_mining /app/parma_mining
 
+ENV ANALYTICS_BASE_URL=$ANALYTICS_BASE_URL
+
+
 EXPOSE 8080
 
 ENTRYPOINT ["/usr/local/bin/_entrypoint.sh"]

--- a/terraform/module/service.tf
+++ b/terraform/module/service.tf
@@ -35,6 +35,10 @@ resource "google_cloud_run_service" "parma_mining_producthunt_cloud_run" {
         ports {
           container_port = 8080
         }
+        env {
+          name  = "ANALYTICS_BASE_URL"
+          value = var.ANALYTICS_BASE_URL
+        }
       }
     }
   }

--- a/terraform/module/variables.tf
+++ b/terraform/module/variables.tf
@@ -12,3 +12,8 @@ variable "region" {
   description = "Google Cloud Region"
   type        = string
 }
+
+variable "ANALYTICS_BASE_URL" {
+  description = "value"
+  type        = string
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -33,4 +33,5 @@ module "main" {
   env              = "prod"
   project          = local.project
   region           = local.region
+  ANALYTICS_BASE_URL = var.ANALYTICS_BASE_URL
 }

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -1,0 +1,4 @@
+variable "ANALYTICS_BASE_URL" {
+  description = "value"
+  type        = string
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -33,4 +33,5 @@ module "main" {
   env              = "staging"
   project          = local.project
   region           = local.region
+  ANALYTICS_BASE_URL = var.ANALYTICS_BASE_URL
 }

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -1,0 +1,4 @@
+variable "ANALYTICS_BASE_URL" {
+  description = "value"
+  type        = string
+}


### PR DESCRIPTION
# Motivation

Analytics Base Url was missing in the template code but added in [this PR](https://github.com/la-famiglia-jst2324/parma-mining-template/pull/14).

# Changes

- Analytics base URL environment variable added into the pipeline & terraform & dockerfile

# Checklist

- [x] added myself as assignee
- [x] correct reviewers
- [x] descriptive PR title using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] description explains the motivation and details of the changes
- [x] tests cover my changes
- [x] my functions are fully typed
- [x] documentation is updated
- [x] CI is green
- [x] breaking changes are discussed with the team and documented in the PR title `!` (e.g. `feat!: Update endpoint`)
