### PR TITLE
refactor: Support different log levels for different environments

### DIFF
--- a/parma_mining/producthunt/api/main.py
+++ b/parma_mining/producthunt/api/main.py
@@ -1,9 +1,18 @@
 """Main entrypoint for the API routes in of parma-analytics."""
 import logging
+import os
 
 from fastapi import FastAPI, status
 
-logging.basicConfig(level=logging.INFO)
+env = os.getenv("env", "local")
+
+if env == "prod":
+    logging.basicConfig(level=logging.INFO)
+elif env in ["staging", "local"]:
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.warning(f"Unknown environment '{env}'. Defaulting to INFO level.")
+    logging.basicConfig(level=logging.INFO)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Motivation

With this PR, we are aiming to change the log level based on the environment.

`env` variable is already set in the terraform `main.tf` files. For local testing, it supports empty `env` variable.

# Changes

- main.py edited and support for different env added.

# Checklist

- [x] added myself as assignee
- [x] correct reviewers
- [x] descriptive PR title using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] description explains the motivation and details of the changes
- [x] tests cover my changes
- [x] documentation is updated
- [x] CI is green
- [x] breaking changes are discussed with the team and documented in the PR title `!` (e.g. `feat!: Update endpoint`)
