### PR TITLE
fix: Deployment error and update timeouts

### DIFF
--- a/parma_mining/producthunt/analytics_client.py
+++ b/parma_mining/producthunt/analytics_client.py
@@ -34,7 +34,7 @@ class AnalyticsClient:
             "Authorization": f"Bearer {token}",
         }
 
-        response = httpx.post(api_endpoint, json=data, headers=headers)
+        response = httpx.post(api_endpoint, json=data, headers=headers, timeout=120)
 
         if response.status_code in [status.HTTP_200_OK, status.HTTP_201_CREATED]:
             return response.json()

--- a/parma_mining/producthunt/ph_client.py
+++ b/parma_mining/producthunt/ph_client.py
@@ -75,7 +75,7 @@ class ProductHuntClient:
 
         try:
             with httpx.Client() as client:
-                response = client.get(search_url, params=params)
+                response = client.get(search_url, params=params, timeout=30)
 
             soup = BeautifulSoup(response.content, "html.parser")
 
@@ -101,7 +101,7 @@ class ProductHuntClient:
 
     def _get_html_content(self, url: str) -> str:
         with httpx.Client() as client:
-            response = client.get(url)
+            response = client.get(url, timeout=30)
         return response.content
 
     def scrape_product_page(self, url: str) -> ProductInfo:

--- a/terraform/module/main.tf
+++ b/terraform/module/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6"
+      version = "5.12.0"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/module/service.tf
+++ b/terraform/module/service.tf
@@ -32,6 +32,15 @@ resource "google_cloud_run_service" "parma_mining_producthunt_cloud_run" {
     spec {
       containers {
         image = data.local_file.image_name.content
+
+        resources {
+          limits = {
+            # 0.5 vCPU, 256 MB RAM for ${var.env} == staging, else 1 vCPU, 512 MB RAM
+            cpu    = var.env == "staging" ? "1" : "1"
+            memory = var.env == "staging" ? "256Mi" : "512Mi"
+          }
+        }
+
         ports {
           container_port = 8080
         }
@@ -49,6 +58,13 @@ resource "google_cloud_run_service" "parma_mining_producthunt_cloud_run" {
         }
       }
     }
+
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale" = "10"
+      }
+    }
+
   }
 
   traffic {

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6"
+      version = "5.12.0"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6"
+      version = "5.12.0"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
# Motivation

GCP made some API adjustments invalidating the defaults in our used terraform providers.

httpx’s default timeout of 5 seconds is updated.